### PR TITLE
feat: support z.input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # typedoc-plugin-zod
 
-Improves display of types created with [Zod](https://github.com/colinhacks/zod)'s `z.infer` type.
+Improves display of types created with [Zod](https://github.com/colinhacks/zod)'s `z.infer` and `z.input` types.
 
 ## Usage
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -40,7 +40,8 @@ export function load(app: Application) {
             !refl.kindOf(ReflectionKind.TypeAlias) ||
             refl.type?.type !== "reference" ||
             refl.type.package !== "zod" ||
-            refl.type.qualifiedName !== "TypeOf"
+            (refl.type.qualifiedName !== "TypeOf" &&
+                refl.type.qualifiedName !== "input")
         ) {
             return;
         }

--- a/src/testdata/input.ts
+++ b/src/testdata/input.ts
@@ -5,12 +5,12 @@ import z from "zod";
  *
  * ```ts
  * export const abc = zod.object({
- *     prop: zod.string(),
+ *     prop: z.string(),
  *     other: zod.object({
  *         arr: zod.array(zod.number()),
  *     }),
  *     opt: z.string().optional(),
- *     def: z.string().default("abc"),
+ *     def: z.string().default('abc')
  * });
  * ```
  */
@@ -24,11 +24,11 @@ export const abc = z.object({
 });
 
 /**
- * Exported type alias which infers its type using the {@link abc} schema.
+ * Exported type alias which infers its input type using the {@link abc} schema.
  *
  * This is declared as:
  * ```ts
- * export type Abc = zod.infer<typeof abc>;
+ * export type Abc = zod.input<typeof abc>;
  * ```
  */
-export type Abc = z.infer<typeof abc>;
+export type Abc = z.input<typeof abc>;


### PR DESCRIPTION
This adds support for types created via `z.input`.

These types are useful if defaults or other `ZodEffects` are used.

See https://zod.dev/?id=guides-and-concepts